### PR TITLE
Reducing segmentation fault cause in main memory code

### DIFF
--- a/cache.h
+++ b/cache.h
@@ -117,7 +117,7 @@ typedef struct L2_cache
 L1_cache* initialize_L1_cache (int cache_type);
 unsigned int search_L1_cache (L1_cache* l1_cache, unsigned int physical_address, unsigned int write_data, int access_type);
 void L1_cache_way_halting_function (L1_cache* l1_cache, unsigned int halt_tag);
-void update_L1_cache (L1_cache* l1_cache, L2_cache* l2_cache, unsigned int *data, unsigned int physical_address);
+void update_L1_cache (L1_cache* l1_cache, L2_cache* l2_cache, unsigned int *fetched_data, unsigned int physical_address);
 void update_L1_LRU_counter (L1_cache *l1_cache, int set_index, int way_index);
 int get_L1_LRU_entry_index (L1_cache* l1_cache, int set_index);
 void print_L1_cache (L1_cache *l1_cache);

--- a/mainmemory.c
+++ b/mainmemory.c
@@ -37,22 +37,11 @@ void pcb_init()
 main_memory* mm;
 frame_table* f_table;
 second_chance_fifo_queue* second_chance_fifo;
-int total_page_count;
-int frame_table_index;
+extern page_table_lru_queue page_table_lru;
+extern int total_page_count;
+extern int frame_table_index;
 
 extern page_table_entry* get_page_entry(unsigned int block_number, PCB* temp_pcb, Proc_Access_Info* temp_pai);
-
-main_memory* main_memory_init()
-{
-    main_memory* mm;
-    mm = (main_memory*)malloc(sizeof(main_memory));
-    frame_table_index=0;
-    mm->total_access_count=0;
-    mm->access_hit_count=0;
-    total_page_count = 0;
-    frame_table_index = 0;
-    return mm;
-}
 
 second_chance_fifo_queue* second_chance_replacement_init()
 {
@@ -65,6 +54,22 @@ second_chance_fifo_queue* second_chance_replacement_init()
     second_chance_fifo->tail->next = NULL;
     second_chance_fifo->tail->prev = second_chance_fifo->head;
     return second_chance_fifo;
+}
+
+main_memory* main_memory_init()
+{
+    main_memory* mm;
+    mm = (main_memory*)malloc(sizeof(main_memory));
+    //initialize linked lists for pages and mm blocks//
+    second_chance_fifo = second_chance_replacement_init();
+    page_table_lru = page_table_lru_init();
+
+    frame_table_index=0;
+    mm->total_access_count=0;
+    mm->access_hit_count=0;
+    total_page_count = 0;
+    frame_table_index = 0;
+    return mm;
 }
 
 data_byte* get_l1_block(unsigned int block_number/* physical address/32 */) //called from l1 cache//

--- a/mainmemory.c
+++ b/mainmemory.c
@@ -4,19 +4,19 @@
 
 #include "pagetable.h"
 #include "mainmemory.h"
-//#include "processes.h"
+#include "processes.h"
 
 #define PAGE_TABLE_LIMIT 1019
 #define PER_PROCESS_PAGE_LIMIT 256
 
 ///////TEMPORARY DECARATIONS TILL CODE IS INTEGRATED//
-typedef struct pcb
-{
-    unsigned int pid:16;
-    page_table* page_fir_base_addr;
-    unsigned int page_count;
-} pcb;
-pcb* temp_pcb;
+// typedef struct pcb
+// {
+//     unsigned int pid:16;
+//     page_table* page_fir_base_addr;
+//     unsigned int page_count;
+// } pcb;
+PCB* temp_pcb;
 
 // typedef struct Proc_Access_Info
 // {
@@ -28,7 +28,7 @@ Proc_Access_Info* temp_pai;
 
 void pcb_init()
 {
-    temp_pcb = (pcb*)malloc(sizeof(pcb));
+    temp_pcb = (PCB*)malloc(sizeof(PCB));
     printf("pcb init\n");
     return;
 }
@@ -40,7 +40,7 @@ second_chance_fifo_queue* second_chance_fifo;
 int total_page_count;
 int frame_table_index;
 
-extern page_table_entry* get_page_entry(unsigned int block_number, pcb* temp_pcb, Proc_Access_Info* temp_pai);
+extern page_table_entry* get_page_entry(unsigned int block_number, PCB* temp_pcb, Proc_Access_Info* temp_pai);
 
 main_memory* main_memory_init()
 {

--- a/pagetable.c
+++ b/pagetable.c
@@ -12,14 +12,14 @@
 #define UNSHARED 0
 
 ///////TEMPORARY DECARATIONS TILL CODE IS INTEGRATED//
-typedef struct pcb
-{
-    unsigned int pid;
-    page_table* page_dir_base_addr;
-    unsigned int page_count;
-    unsigned int num_main_memory_hits;
-    unsigned int num_main_memory_misses;
-} PCB;
+// typedef struct pcb
+// {
+//     unsigned int pid;
+//     page_table* page_dir_base_addr;
+//     unsigned int page_count;
+//     unsigned int num_main_memory_hits;
+//     unsigned int num_main_memory_misses;
+// } PCB;
 
 // typedef struct Proc_Access_Info
 // {


### PR DESCRIPTION
Some structures were not initialised, and were causing seg faults. Some more to go